### PR TITLE
Remove protocol in href attributes in scripts

### DIFF
--- a/plz-suche/index.html
+++ b/plz-suche/index.html
@@ -4,9 +4,9 @@
         <title>Postleitzahlensuche mit HTML &amp; jQuery</title>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
         <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
-        <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+        <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
         <script src="./js/papaparse.min.js"></script>
     </head>
     <body style="background: #fdfdfd;">


### PR DESCRIPTION
Fixed errors in loading scripts and CSS-styles over an unprotected HTTP protocol: 

```
Mixed Content: The page at 'https://rawgit.com/plzTeam/web-snippets/master/plz-suche/index.html' 
was loaded over HTTPS, but requested an insecure stylesheet 
'http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css'. 
This request has been blocked; the content must be served over HTTPS.

Mixed Content: The page at 'https://rawgit.com/plzTeam/web-snippets/master/plz-suche/index.html' 
was loaded over HTTPS, but requested an insecure script 
'http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js'. 
This request has been blocked; the content must be served over HTTPS.
```